### PR TITLE
Store uploaded CV documents in SQLite database

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,32 @@ class MyApp extends StatelessWidget {
 }
 ```
 
+### Setting up SQLite Database
+
+1. Install SQLite:
+
+```bash
+sudo apt-get install sqlite3
+```
+
+2. Create the SQLite database file:
+
+```bash
+sqlite3 cv.db
+```
+
+3. Create the `cv` table in the database:
+
+```sql
+CREATE TABLE cv (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    fileName TEXT NOT NULL,
+    downloadURL TEXT NOT NULL,
+    uploadedAt TEXT NOT NULL,
+    extractedInfo TEXT
+);
+```
+
 ### Running the application
 
 1. Run the Flutter web application:

--- a/api/database.py
+++ b/api/database.py
@@ -1,0 +1,35 @@
+import sqlite3
+from datetime import datetime
+
+def initialize_db():
+    conn = sqlite3.connect('cv.db')
+    cursor = conn.cursor()
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS cv (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            fileName TEXT NOT NULL,
+            downloadURL TEXT NOT NULL,
+            uploadedAt TEXT NOT NULL,
+            extractedInfo TEXT
+        )
+    ''')
+    conn.commit()
+    conn.close()
+
+def insert_cv(fileName, downloadURL, uploadedAt, extractedInfo):
+    conn = sqlite3.connect('cv.db')
+    cursor = conn.cursor()
+    cursor.execute('''
+        INSERT INTO cv (fileName, downloadURL, uploadedAt, extractedInfo)
+        VALUES (?, ?, ?, ?)
+    ''', (fileName, downloadURL, uploadedAt, extractedInfo))
+    conn.commit()
+    conn.close()
+
+def get_cvs():
+    conn = sqlite3.connect('cv.db')
+    cursor = conn.cursor()
+    cursor.execute('SELECT * FROM cv')
+    rows = cursor.fetchall()
+    conn.close()
+    return rows

--- a/api/main.py
+++ b/api/main.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 from typing import List
 import shutil
 import os
+from api.database import initialize_db, insert_cv, get_cvs_from_db
 
 app = FastAPI()
 
@@ -20,9 +21,11 @@ class MatchingResult(BaseModel):
 cvs = []
 matching_results = []
 
+initialize_db()
+
 @app.get("/api/cvs", response_model=List[CV])
 async def get_cvs():
-    return cvs
+    return get_cvs_from_db()
 
 @app.post("/api/cvs")
 async def upload_cv(file: UploadFile = File(...)):
@@ -36,7 +39,7 @@ async def upload_cv(file: UploadFile = File(...)):
         uploadedAt="2023-01-01T00:00:00Z",
         extractedInfo={}
     )
-    cvs.append(cv)
+    insert_cv(cv.fileName, cv.downloadURL, cv.uploadedAt, cv.extractedInfo)
     return {"info": "CV uploaded successfully"}
 
 @app.get("/api/matching_results", response_model=List[MatchingResult])


### PR DESCRIPTION
Add SQLite database to store uploaded CV documents.

* Create `api/database.py` to handle SQLite database operations
  - Define functions to initialize the database, insert CV metadata, and retrieve CV metadata
* Modify `api/main.py` to integrate SQLite database
  - Import SQLite database functions
  - Initialize the database
  - Modify `upload_cv` function to store CV metadata in the database
  - Update `get_cvs` function to retrieve CV metadata from the database
* Update `README.md` to include instructions for setting up the SQLite database

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lserinol/cv-matching-app/pull/3?shareId=2834ad92-2dbe-40a9-988c-df5065378090).